### PR TITLE
Remove dependency on FeatureType managing custom "print" configuration

### DIFF
--- a/Element/Search.php
+++ b/Element/Search.php
@@ -245,8 +245,7 @@ class Search extends BaseElement
             $featureTypeName = $schema->getFeatureType();
             $declaration     = $featureTypeDeclarations[ $featureTypeName ];
             $title           = isset($declaration['title']) ? $declaration['title'] : ucfirst($featureTypeName);
-            $featureType     = $featureTypeManager->get($featureTypeName);
-            $print           = $featureType->getConfiguration('print');
+            $print = isset($declaration['print']) ? $declaration['print'] : null;
             $fields          = $schema->getFields();
 
             foreach ($fields as &$fieldDescription) {


### PR DESCRIPTION
Featuretype configuration entry `print` is completely custom to mapbender/search and not maintained in upstream.

Current version creates a FeatureType with a prepared configuration possibly containing a `print` entry, and uses that FeatureType _only_ to re-extract that `print` entry.

Single commit on this branch replaces that logic with direct extraction from the prepared configuration. No FeatureType object is created.

This reinstates compatibility with current mapbender/data-source in the `schemas/list` http interaction.

Please confirm if the `schemas/list` interaction still works.