### PR TITLE
Switch feature format from (phayes/geophp-provided) GeoJSON to list of WKTs

### DIFF
--- a/Component/QueryManager.php
+++ b/Component/QueryManager.php
@@ -152,10 +152,25 @@ class QueryManager extends BaseManager
     public function fetchQuery(Query $query, array $args = array())
     {
         $featureType = $this->getQueryFeatureType($query);
-        return $featureType->search(array_merge(array(
+        $features = $featureType->search(array_merge(array(
             'where'      => $this->buildCriteria($query->getConditions(), $featureType),
-            'returnType' => 'FeatureCollection'
         ), $args));
+
+        $geometryField = $featureType->getGeomField();
+
+        $formatted = array();
+        foreach ($features as $feature) {
+            $properties = $feature->toArray();
+            // remove (variable) geometry column from properties
+            unset($properties[$geometryField]);
+            $formatted[] = array(
+                'geometry' => $feature->getGeom(),  // NOTE: WKT format
+                'properties' => $properties,
+            );
+        }
+        return array(
+            'features' => $formatted,
+        );
     }
 
     /**

--- a/Resources/public/mapbender.element.search.js
+++ b/Resources/public/mapbender.element.search.js
@@ -463,13 +463,16 @@
 
             query.titleView.queryResultTitleBarView('showPreloader');
 
+            var wktListReader = function(featureData) {
+                return (featureData || []).map(function(entry) {
+                    var geometry = OpenLayers.Geometry.fromWKT(entry.geometry);
+                    return new OpenLayers.Feature.Vector(geometry, entry.properties);
+                });
+            };
+
             if(!query.extendOnly && query._rowFeatures) {
                 setTimeout(function() {
-                    var geoJsonReader = new OpenLayers.Format.GeoJSON();
-                    var featureCollection = geoJsonReader.read({
-                        type:     "FeatureCollection",
-                        features: query._rowFeatures
-                    });
+                    var featureCollection = wktListReader(query._rowFeatures);
                     query.resultView.queryResultView('updateList', featureCollection);
                     widget.reloadFeatures(query, featureCollection);
                     query.titleView.queryResultTitleBarView('hidePreloader');
@@ -497,11 +500,7 @@
 
                 query._rowFeatures = r.features;
 
-                var geoJsonReader = new OpenLayers.Format.GeoJSON();
-                var featureCollection = geoJsonReader.read({
-                    type:     "FeatureCollection",
-                    features: r.features
-                });
+                var featureCollection = wktListReader(r.features);
 
                 query.resultView.queryResultView('updateList', featureCollection);
                 widget.reloadFeatures(query, featureCollection);


### PR DESCRIPTION
Changes feature format in the `query/fetch` http action (running a stored query) from GeoJSON to list of WKTs and feature properties.

Rationale: the GeoJSON format is provided in upstream mapbender/data-source by [phayes/geophp](https://packagist.org/packages/phayes/geophp), which is unmaintained since 2014 and is starting to cause PHP language problems.

This GeoJSON format is also most likely invalid (does not respect GeoJSON's predefined CRS at all), and thus not interopable with anything outside the current Mapbender cosmos.

mapbender/search is the _only_ remaining piece of software that uses the GeoJSON path in mapbender/data-source's FeatureType::search.

If we resolve this invocation, the GeoJSON path, and with it the phayes/geophp dependency, are safe to drop.

Please confirm if stored queries still execute as expected, and the resulting features have all the expected properties.
