### PR TITLE
Fix/resolve zumba dependency

### DIFF
--- a/Element/Search.php
+++ b/Element/Search.php
@@ -16,9 +16,7 @@ use Mapbender\SearchBundle\Component\StyleMapManager;
 use Mapbender\SearchBundle\Entity\QuerySchema;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Zumba\Util\JsonSerializer;
 
 /**
  * Class Search
@@ -188,13 +186,6 @@ class Search extends BaseElement
                 break;
         }
         throw new BadRequestHttpException("Invalid action " . var_export($action, true));
-    }
-
-    private function zumbaResponse($data)
-    {
-        $serializer = new JsonSerializer();
-        $responseBody = $serializer->serialize($data);
-        return new Response($responseBody, 200, array('Content-Type' => 'application/json'));
     }
 
     /**

--- a/Element/Search.php
+++ b/Element/Search.php
@@ -136,7 +136,7 @@ class Search extends BaseElement
             case 'schemas/list':
                 return $this->listSchemasAction();
             case 'query/fetch':
-                return $this->zumbaResponse($this->fetchQueryAction($this->getRequestData()));
+                return new JsonResponse($this->fetchQueryAction($this->getRequestData()));
             case 'query/check':
                 return $this->checkQueryAction($this->getRequestData());
             case 'export':


### PR DESCRIPTION
Replaces [zumba/json-serializer](https://packagist.org/packages/zumba/json-serializer) with plain-old Symfony JsonResponse. 

mapbender/search does not itself declare a dependency on zumba/json-serializer. Instead, mapbender/data-source is expected to depend on zumba/json-serializer, but only mapbender/search uses it. The version required is 1.0.x, which means we are using a version last maintained in 2014.

mapbender/search cannot update the dependency to a newer version, because it would immediately break mapbender/search.

mapbender/search does not work without Mapbender, wich does not work without Symfony, so Symfony's JsonResponse will always be available.

Zumba's serializer is designed for freezing and recreating PHP objects, which is wholly irrelevant in this usage. OTOH Symfony's version is more robust in handling plain-old-data vs various PHP version quirks.

If mapbender/search stops using the Zumba serializer, mapbender/data-source can safely drop the dependency. This will save further no coordination efforts when, where and how to update the zumba/json-serializer dependency to a maintained version.

Please confirm if stored queries can still be executed correctly with this change.